### PR TITLE
clarify readme for proper example using multiple files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ Specify the number of threads to execute the check. Default is the number of CPU
 Below command can check if the headers are self contained in my [eventpp library](https://github.com/wqking/eventpp)
 
 ```
-python cpp-header-checker.py complete --source EVENTPP_FOLDER/include/**/*.h --temp ./temp --command "gcc {file} -c -o {file}.o -IEVENTPP_FOLDER/include" --exclude _i.h
+python cpp-header-checker.py complete --source "EVENTPP_FOLDER/include/**/*.h" --temp ./temp --command "gcc {file} -c -o {file}.o -IEVENTPP_FOLDER/include" --exclude _i.h
 ```
 
 #### Check redundant #include for eventpp library
@@ -83,7 +83,7 @@ python cpp-header-checker.py complete --source EVENTPP_FOLDER/include/**/*.h --t
 Below command can check if any `#include` is redundant in my [eventpp library](https://github.com/wqking/eventpp)
 
 ```
-python cpp-header-checker.py redundant --source EVENTPP_FOLDER/include/**/*.h --temp ./temp --command "gcc {file} -c -o {file}.o -IEVENTPP_FOLDER/include" --exclude _i.h
+python cpp-header-checker.py redundant --source "EVENTPP_FOLDER/include/**/*.h" --temp ./temp --command "gcc {file} -c -o {file}.o -IEVENTPP_FOLDER/include" --exclude _i.h
 ```
 
 ## How it works


### PR DESCRIPTION
In testing your tool I noticed that when using the example as stated in the current readme, there is always an error when there are multiple files to be analyzed that result from using the wildcard character in the `--source` path.
The error then looks like this:
`cpp-header-checker.py: error: unrecognized arguments: eventpp/include/eventpp/eventdispatcher.h eventpp/include/eventpp/eventpolicies.h eventpp/include/eventpp/eventqueue.h eventpp/include/eventpp/hetercallbacklist.h eventpp/include/eventpp/hetereventdispatcher.h eventpp/include/eventpp/hetereventqueue.h`

I found that this bug has to do with the parser interpreting the other files, which are always separated by whitespace, as another argument, which is not the case. Adding quotation marks to the source path ensures that tool works with multiple files.

I don't know if you @wqking had the same usage and this is an error in the readme or if this is system specific. However, I am also using Python 3.8.10 (& Ubuntu 20.04, gcc 9.3.0).